### PR TITLE
Prevent build failures by updating Node and using globally-installed Gulp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,9 @@ RUN apt-get -qq update && \
       lsb-release python-all rlwrap redis-server libpng-dev git python-minimal supervisor && \
     apt-get autoremove -qq && apt-get clean && rm -rf /usr/share/doc /usr/share/man /var/log/* /tmp/*
 
-RUN curl https://deb.nodesource.com/node/pool/main/n/nodejs/nodejs_0.10.36-1nodesource1~jessie1_amd64.deb \
-        > node.deb && dpkg -i node.deb && rm node.deb
+RUN curl -o /usr/local/bin/n https://raw.githubusercontent.com/visionmedia/n/master/bin/n && \
+    chmod +x /usr/local/bin/n && \
+    n stable
 
 # Clone code
 RUN git clone --depth=1 http://github.com/vatesfr/xo-server && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,10 @@ RUN git clone --depth=1 http://github.com/vatesfr/xo-server && \
 # Build dependancies then cleanup
 RUN apt-get -qq install --no-install-recommends make gcc g++ && \
         npm install -g npm --unsafe-perm && \
+	npm install -g gulp --unsafe-perm && \
         cd /app/xo-server && npm install --unsafe-perm && \
     cd /app/xo-web && npm install --unsafe-perm && \
-    /app/xo-web/gulp --production && \
+    gulp --production && \
     rm -rf ~/.npm /tmp/* /var/log/* /app/xo-web/node_modules \
         /var/lib/apt/lists/* && npm cache clean && \
     apt-get purge -qq gcc g++ make && apt-get clean -qq && \


### PR DESCRIPTION
This wouldn't build for me out-of-the-box. Firstly, the build failed with `No such file: /app/xo-web/gulp` and secondly by throwing up `ReferenceError: Promise is not defined` when running the Gulp build.

The former was fixed by installing gulp globally, and the second was fixed by updating Node.
